### PR TITLE
Fix for jQuery hotkeys being triggered in password fields.

### DIFF
--- a/jquery.hotkeys.js
+++ b/jquery.hotkeys.js
@@ -44,7 +44,7 @@
 		handleObj.handler = function( event ) {
 			// Don't fire in text-accepting inputs that we didn't directly bind to
 			if ( this !== event.target && (/textarea|select/i.test( event.target.nodeName ) ||
-				 event.target.type === "text") ) {
+				 event.target.type === "text" || event.target.type === "password") ) {
 				return;
 			}
 			


### PR DESCRIPTION
If you're in an input box of the password type, your hotkeys will still be triggered, unlike for normal input fields, because it only checks for event.target.type === "text". I've fixed that in this fork by also checking for "password", based on the details listed on [Google Code](http://code.google.com/p/js-hotkeys/issues/detail?id=84).

This is my first GitHub pull request. And my first contribution to another open source project. I think I did everything right (not that there was much to it).
