### PR TITLE
Password and HTML5 input types

### DIFF
--- a/jquery.hotkeys.js
+++ b/jquery.hotkeys.js
@@ -39,12 +39,13 @@
 		}
 		
 		var origHandler = handleObj.handler,
-			keys = handleObj.data.toLowerCase().split(" ");
+			keys = handleObj.data.toLowerCase().split(" "),
+			textAcceptingInputTypes = ["text", "password", "number", "email", "url", "range", "date", "month", "week", "time", "datetime", "datetime-local", "search", "color"];
 	
 		handleObj.handler = function( event ) {
 			// Don't fire in text-accepting inputs that we didn't directly bind to
 			if ( this !== event.target && (/textarea|select/i.test( event.target.nodeName ) ||
-				 event.target.type === "text") ) {
+				jQuery.inArray(event.target.type, textAcceptingInputTypes) > -1 ) ) {
 				return;
 			}
 			


### PR DESCRIPTION
Added password and HTML input types to the list to be ignored for event handling by default.
