### PR TITLE
Disable hotkeys in password inputs

### DIFF
--- a/jquery.hotkeys.js
+++ b/jquery.hotkeys.js
@@ -44,7 +44,7 @@
 		handleObj.handler = function( event ) {
 			// Don't fire in text-accepting inputs that we didn't directly bind to
 			if ( this !== event.target && (/textarea|select/i.test( event.target.nodeName ) ||
-				 event.target.type === "text") ) {
+				 event.target.type === "text" || event.target.type === "password") ) {
 				return;
 			}
 			


### PR DESCRIPTION
A small patch to disable keyboard shortcuts for password fields, unless you've specifically bound to them. Previously only inputs of type text were being ignored.

Great plugin!

Thanks,
  -Nick
