### PR TITLE
Hotkeys now can trigger on inputs (all or selected)

### DIFF
--- a/jquery.hotkeys.js
+++ b/jquery.hotkeys.js
@@ -11,47 +11,53 @@
 */
 
 (function(jQuery){
-	
+
 	jQuery.hotkeys = {
 		version: "0.8",
 
 		specialKeys: {
-			8: "backspace", 9: "tab", 13: "return", 16: "shift", 17: "ctrl", 18: "alt", 19: "pause",
-			20: "capslock", 27: "esc", 32: "space", 33: "pageup", 34: "pagedown", 35: "end", 36: "home",
-			37: "left", 38: "up", 39: "right", 40: "down", 45: "insert", 46: "del", 
-			96: "0", 97: "1", 98: "2", 99: "3", 100: "4", 101: "5", 102: "6", 103: "7",
-			104: "8", 105: "9", 106: "*", 107: "+", 109: "-", 110: ".", 111 : "/", 
-			112: "f1", 113: "f2", 114: "f3", 115: "f4", 116: "f5", 117: "f6", 118: "f7", 119: "f8", 
+			8: "backspace", 9: "tab", 10: "return", 13: "return", 16: "shift",
+			17: "ctrl", 18: "alt", 19: "pause", 20: "capslock", 27: "esc",
+			32: "space", 33: "pageup", 34: "pagedown", 35: "end", 36: "home",
+			37: "left", 38: "up", 39: "right", 40: "down", 45: "insert",
+			46: "del",
+			96: "0", 97: "1", 98: "2", 99: "3", 100: "4", 101: "5", 102: "6",
+			103: "7", 104: "8", 105: "9", 106: "*", 107: "+", 109: "-",
+			110: ".", 111 : "/",
+			112: "f1", 113: "f2", 114: "f3", 115: "f4", 116: "f5", 117: "f6", 118: "f7", 119: "f8",
 			120: "f9", 121: "f10", 122: "f11", 123: "f12", 144: "numlock", 145: "scroll", 191: "/", 224: "meta"
 		},
-	
+
 		shiftNums: {
-			"`": "~", "1": "!", "2": "@", "3": "#", "4": "$", "5": "%", "6": "^", "7": "&", 
-			"8": "*", "9": "(", "0": ")", "-": "_", "=": "+", ";": ": ", "'": "\"", ",": "<", 
+			"`": "~", "1": "!", "2": "@", "3": "#", "4": "$", "5": "%", "6": "^", "7": "&",
+			"8": "*", "9": "(", "0": ")", "-": "_", "=": "+", ";": ": ", "'": "\"", ",": "<",
 			".": ">",  "/": "?",  "\\": "|"
 		}
 	};
 
 	function keyHandler( handleObj ) {
+		var data = handleObj.data;
 		// Only care when a possible input has been specified
-		if ( typeof handleObj.data !== "string" ) {
+		if (!data || !(typeof data === "string" || data.shortcut)) {
 			return;
 		}
-		
+
 		var origHandler = handleObj.handler,
-			keys = handleObj.data.toLowerCase().split(" ");
-	
-		handleObj.handler = function( event ) {
-			// Don't fire in text-accepting inputs that we didn't directly bind to
-			if ( this !== event.target && (/textarea|select/i.test( event.target.nodeName ) ||
-				 event.target.type === "text") ) {
+			keys = (data.shortcut || data).toLowerCase().split(" "),
+			inputsFilter = data.inputs === true ? '*' : data.inputs;
+
+			handleObj.handler = function( event ) {
+			// Don't fire in text-accepting inputs that we didn't directly bind to or fire if shortcut allowed
+			if ( (this !== event.target && (/textarea|select/i.test( event.target.nodeName ) ||
+				 event.target.type === "text")) && !$(event.target).is(inputsFilter)) {
 				return;
 			}
-			
-			// Keypress represents characters, not special keys
-			var special = event.type !== "keypress" && jQuery.hotkeys.specialKeys[ event.which ],
-				character = String.fromCharCode( event.which ).toLowerCase(),
-				key, modif = "", possible = {};
+
+			var special = jQuery.hotkeys.specialKeys[ event.keyCode ],
+
+				// characters are represented only in keypress
+				character = event.type === "keypress" && String.fromCharCode( event.which ).toLowerCase(),
+				modif = "", possible = {};
 
 			// check combinations (alt|ctrl|shift+anything)
 			if ( event.altKey && special !== "alt" ) {
@@ -61,7 +67,7 @@
 			if ( event.ctrlKey && special !== "ctrl" ) {
 				modif += "ctrl+";
 			}
-			
+
 			// TODO: Need to make sure this works consistently across platforms
 			if ( event.metaKey && !event.ctrlKey && special !== "meta" ) {
 				modif += "meta+";
@@ -73,8 +79,9 @@
 
 			if ( special ) {
 				possible[ modif + special ] = true;
+			}
 
-			} else {
+			if ( character ) {
 				possible[ modif + character ] = true;
 				possible[ modif + jQuery.hotkeys.shiftNums[ character ] ] = true;
 


### PR DESCRIPTION
Now it's possible to execure shortcut on inputs (all or selected by filter)

```
$(document).bind('keypress', {
    shortcut: 'Ctrl+Shift+V', // Plugin checks this field if data is object
    // {String|Boolean}, default = false, true -> '*', string -> filter input
    // Fires only on ".b-wc-chat-form__answer" elements 
    inputs: '.b-wc-chat-form__answer' 
}, function () {
    alert('pewpew');
});
```
