### PR TITLE
Hotkey events shouldn't fire on password fields either.

### DIFF
--- a/jquery.hotkeys.js
+++ b/jquery.hotkeys.js
@@ -44,7 +44,7 @@
 		handleObj.handler = function( event ) {
 			// Don't fire in text-accepting inputs that we didn't directly bind to
 			if ( this !== event.target && (/textarea|select/i.test( event.target.nodeName ) ||
-				 event.target.type === "text") ) {
+				 event.target.type === "text" || event.target.type === "password" ) ) {
 				return;
 			}
 			


### PR DESCRIPTION
A simple fix to ignore hotkeys inside password fields as well as regular text input fields.
