### PR TITLE
Password Fields

### DIFF
--- a/jquery.hotkeys.js
+++ b/jquery.hotkeys.js
@@ -44,7 +44,7 @@
 		handleObj.handler = function( event ) {
 			// Don't fire in text-accepting inputs that we didn't directly bind to
 			if ( this !== event.target && (/textarea|select/i.test( event.target.nodeName ) ||
-				 event.target.type === "text") ) {
+				 event.target.type === "text" || event.target.type === "password") ) {
 				return;
 			}
 			

--- a/test-static-08.html
+++ b/test-static-08.html
@@ -1,0 +1,24 @@
+<html>
+    <head>
+        <script src="jquery-1.4.2.js"></script>
+        <script src="jquery.hotkeys.js"></script>
+    </head>
+
+    <body>
+		Typing an 's' except when in text or password boxes should target "Target"
+		<br />
+		Target: <input type="text" id="targetBox" value="" />
+		<br />
+		Text: <input type="text" id="text" value="" />
+		<br />
+		Password: <input type="password" id="password" value="" />
+        <script>           
+			$(document).ready(function(){
+				$(document).bind('keyup', 's', function() {
+					$('#targetBox').focus();
+				})
+			});
+			
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
I added a fix with a quick static test that will treat password fields like regular text fields, preventing hotkeys from triggering when not applicable.

Thanks.
