### PR TITLE
Fixed plug-in to handle !event.which events

### DIFF
--- a/jquery.hotkeys.js
+++ b/jquery.hotkeys.js
@@ -49,9 +49,10 @@
 			}
 			
 			// Keypress represents characters, not special keys
-			var special = event.type !== "keypress" && jQuery.hotkeys.specialKeys[ event.which ],
-				character = String.fromCharCode( event.which ).toLowerCase(),
-				key, modif = "", possible = {};
+			var which = typeof event.which != "undefined" ? event.which : event.keyCode;
+			var special = event.type !== "keypress" && jQuery.hotkeys.specialKeys[ which ],
+			    character = String.fromCharCode( which ).toLowerCase(),
+			    key, modif = "", possible = {};
 
 			// check combinations (alt|ctrl|shift+anything)
 			if ( event.altKey && special !== "alt" ) {


### PR DESCRIPTION
Fixed plug-in to consider event.keyCode in cases when there is no event.which. For me, this happened when manually .triggering an keydown event from an automatically triggered keydown. This may just be a bug in jQuery, but since it didn't change between 1.4.2 and the current (1.7.1) version, and since I see no bug reports for it, I'm thinking it's expected behavior (in which case this plug-in should adjust accordingly).
