### PR TITLE
Passing other arguments to binding

### DIFF
--- a/jquery.hotkeys.js
+++ b/jquery.hotkeys.js
@@ -38,6 +38,10 @@
 	};
 
 	function keyHandler( handleObj ) {
+		if ( typeof handleObj.data === "string" ) {
+			handleObj.data = { keys: handleObj.data };
+		}
+
 		// Only care when a possible input has been specified
 		if ( !handleObj.data.keys || typeof handleObj.data.keys !== "string" ) {
 			return;


### PR DESCRIPTION
One small change is: now keys are passed by object { keys: '...' }
Might be useful, when you want to pass some other data to your handler
