### PR TITLE
Allow backbone to bind to keydown/up

### DIFF
--- a/jquery.hotkeys.js
+++ b/jquery.hotkeys.js
@@ -44,7 +44,7 @@
 		}
 
 		// Only care when a possible input has been specified
-		if ( !handleObj.data.keys || typeof handleObj.data.keys !== "string" ) {
+		if ( !handleObj.data || !handleObj.data.keys || typeof handleObj.data.keys !== "string" ) {
 			return;
 		}
 


### PR DESCRIPTION
I was getting an error I think due to backbone event binding to keyup and not providing handleObj.data.

This prevents the js error and seems to be working.
