### PR TITLE
Fix keypress on special keys and keydown/keyup on characters

### DIFF
--- a/jquery.hotkeys.js
+++ b/jquery.hotkeys.js
@@ -58,10 +58,10 @@
 				jQuery.inArray(event.target.type, textAcceptingInputTypes) > -1 ) ) {
 				return;
 			}
-			
-			// Keypress represents characters, not special keys
-			var special = event.type !== "keypress" && jQuery.hotkeys.specialKeys[ event.which ],
-				character = String.fromCharCode( event.which ).toLowerCase(),
+
+			var special = jQuery.hotkeys.specialKeys[ event.keyCode ],
+				// character codes are available only in keypress
+				character = event.type === "keypress" && String.fromCharCode( event.which ).toLowerCase(),
 				modif = "", possible = {};
 
 			// check combinations (alt|ctrl|shift+anything)
@@ -84,8 +84,9 @@
 
 			if ( special ) {
 				possible[ modif + special ] = true;
+			}
 
-			} else {
+			if ( character ) {
 				possible[ modif + character ] = true;
 				possible[ modif + jQuery.hotkeys.shiftNums[ character ] ] = true;
 


### PR DESCRIPTION
This fix allows to handle special keys with `keypress` event (special keys can trigger all kinds of events with valid `keyCode`). It also fixes usage of invalid character codes on `keydown`/`keyup` events (valid `charCode` available only with `keypress` events, though we have to use `which` property because IE passes character codes in `keyCode`)

Reference used: http://www.quirksmode.org/js/keys.html
