### PR TITLE
Allow overriding of filter for text input elements.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -7,14 +7,12 @@ module.exports = function(grunt) {
         "undef": true,
         "unused": true
       },
-
       files: 'jquery.hotkeys.js'
     },
     jasmine: {
       pivotal: {
-        src: 'jquery.hotkeys.js',
         options: {
-          vendor: ['jquery-1.4.2.js', 'test/lib/**.js'],
+          vendor: ['jquery-1.4.2.js', 'jquery.hotkeys.js', 'test/lib/**.js'],
           outfile: 'test/SpecRunner.html',
           keepRunner: true,
           specs: 'test/spec/*Spec.js'

--- a/jquery.hotkeys.js
+++ b/jquery.hotkeys.js
@@ -21,14 +21,14 @@
 		version: "0.8",
 
 		specialKeys: {
-			8: "backspace", 9: "tab", 91: "return", 13: "return", 16: "shift", 17: "ctrl", 18: "alt", 19: "pause",
+			8: "backspace", 9: "tab", 10: "return", 13: "return", 16: "shift", 17: "ctrl", 18: "alt", 19: "pause",
 			20: "capslock", 27: "esc", 32: "space", 33: "pageup", 34: "pagedown", 35: "end", 36: "home",
-			37: "left", 38: "up", 39: "right", 40: "down", 45: "insert", 46: "del",
+			37: "left", 38: "up", 39: "right", 40: "down", 45: "insert", 46: "del", 59: ";", 61: "=",
 			96: "0", 97: "1", 98: "2", 99: "3", 100: "4", 101: "5", 102: "6", 103: "7",
 			104: "8", 105: "9", 106: "*", 107: "+", 109: "-", 110: ".", 111 : "/",
 			112: "f1", 113: "f2", 114: "f3", 115: "f4", 116: "f5", 117: "f6", 118: "f7", 119: "f8",
-			120: "f9", 121: "f10", 122: "f11", 123: "f12", 144: "numlock", 145: "scroll", 186: ";", 191: "/",
-			220: "\\", 222: "'", 224: "meta"
+			120: "f9", 121: "f10", 122: "f11", 123: "f12", 144: "numlock", 145: "scroll", 173: "-", 186: ";", 187: "=",
+			188: ",", 189: "-", 190: ".", 191: "/", 192: "`", 219: "[", 220: "\\", 221: "]", 222: "'"
 		},
 
 		shiftNums: {
@@ -47,10 +47,10 @@
 		}
 	};
 
-	function keyHandler( handleObj ) {
-		if ( typeof handleObj.data === "string" ) {
-			handleObj.data = { keys: handleObj.data };
-		}
+  function keyHandler( handleObj ) {
+    if ( typeof handleObj.data === "string" ) {
+      handleObj.data = { keys: handleObj.data };
+    }
 
 		// Only care when a possible input has been specified
 		if ( !handleObj.data || !handleObj.data.keys || typeof handleObj.data.keys !== "string" ) {
@@ -68,8 +68,6 @@
 				return;
 			}
 
-      var specialKeys = ['alt', 'ctrl', 'meta', 'shift'];
-
 			var special = jQuery.hotkeys.specialKeys[ event.keyCode ],
 				character = String.fromCharCode( event.which ).toLowerCase(),
 				modif = "", possible = {};
@@ -79,6 +77,7 @@
           modif += specialKey + '+';
         }
       });
+
 
       modif = modif.replace('alt+ctrl+meta+shift', 'hyper');
 

--- a/test/SpecRunner.html
+++ b/test/SpecRunner.html
@@ -18,6 +18,8 @@
   
   <script src="../jquery-1.4.2.js"></script>
   
+  <script src="../jquery.hotkeys.js"></script>
+  
   <script src="lib/boot.js"></script>
   
   <script src="lib/console.js"></script>
@@ -29,8 +31,6 @@
   <script src="lib/sinon.js"></script>
   
   <script src="lib/underscore.js"></script>
-  
-  <script src="../jquery.hotkeys.js"></script>
   
   <script src="spec/bindingSpec.js"></script>
   


### PR DESCRIPTION
You can now customize the filter for which events hotkeys will force direct event binding by changing the property `jQuery.hotkeys.textAcceptingInputTypes`

You can also turn this filtering off via `jQuery.hotkeys.options.filterTextInputs = false`
