### PR TITLE
Update dependencies, add missing grunt-contrib-watch dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,11 @@
   "description": "**jQuery Hotkeys** is a plug-in that lets you easily add and remove handlers for keyboard events anywhere in your code supporting almost any key combination.",
   "main": "jquery.hotkeys.js",
   "devDependencies": {
-    "grunt": "~0.4.1",
-    "grunt-contrib-jshint": "~0.8.0",
-    "grunt-contrib-jasmine": "~0.6.0",
-    "grunt-jsbeautifier": "~0.2.7"
+    "grunt": "^0.4.5",
+    "grunt-contrib-jasmine": "^0.7.0",
+    "grunt-contrib-jshint": "^0.10.0",
+    "grunt-contrib-watch": "^0.6.1",
+    "grunt-jsbeautifier": "^0.2.7"
   },
   "repository": {
     "type": "git",

--- a/test/SpecRunner.html
+++ b/test/SpecRunner.html
@@ -3,12 +3,16 @@
 <head>
   <meta charset="utf-8">
   <title>Jasmine Spec Runner</title>
+  <link rel="shortcut icon" type="image/png" href=".grunt/grunt-contrib-jasmine/jasmine_favicon.png">
 
   <link rel="stylesheet" type="text/css" href="../.grunt/grunt-contrib-jasmine/jasmine.css">
 
 
+</head>
+<body>
+
   
-  <script src="../.grunt/grunt-contrib-jasmine/phantom-polyfill.js"></script>
+  <script src="../.grunt/grunt-contrib-jasmine/es5-shim.js"></script>
   
   <script src="../.grunt/grunt-contrib-jasmine/jasmine.js"></script>
   
@@ -37,7 +41,5 @@
   <script src="../.grunt/grunt-contrib-jasmine/reporter.js"></script>
   
 
-</head>
-<body>
 </body>
 </html>


### PR DESCRIPTION
- Use caret instead of ~ for safer dependency management
  - This drops support for running the build on Node 0.8
- Update SpecRunner.html to have new links for ES5 shim
  - This happens automatically when you run tests with grunt-contrib-jasmine@0.7.0
