### PR TITLE
Filter function fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,23 @@ It is known to be working with all the major browsers on all available platforms
  * Safari-3+
  * Chrome-0.2+
 
+## Hotkeys within inputs
+
+Hotkeys aren't tracked if the user is focused within an input element or any element that has `contenteditable="true"` unless you bind the hotkey directly to the element. This helps to avoid conflict with normal user typing. If this is undesired behavior, you can override the filter function:
+
+```js
+jQuery.hotkeys.filter = function(event) {
+  // event.target is the element that triggered the key event
+  // this is the element that the listener is bound to
+  return true; // returning true will allow hotkeys to be tracked
+};
+```
+
 ## Notes
 
 Modifiers are not case sensitive (`Ctrl` == `ctrl` == `cTRL`)
 
 If you want to use more than one modifier (e.g. `alt+ctrl+z`) you should define them by an alphabetical order e.g. alt+ctrl+shift
-
-Hotkeys aren't tracked if you're inside of an input element (unless you explicitly bind the hotkey directly to the input). This helps to avoid conflict with normal user typing.
 
 You can use namespacing by adding a suffix to the event type (e.g. `keyup.toggle`)
 

--- a/jquery.hotkeys.js
+++ b/jquery.hotkeys.js
@@ -109,6 +109,18 @@
       "\\": "|"
     },
 
+    filter: function(event) {
+      var target = event.target;
+
+      var targetIsTextInput = target.isContentEditable || (target.tagName === 'INPUT' && jQuery.inArray(target.type, jQuery.hotkeys.textAcceptingInputTypes) > -1);
+      var shouldFilterTextInput = jQuery.hotkeys.options.filterTextInputs && targetIsTextInput;
+      var targetIsTextAreaOrSelect = !/textarea|select/i.test(target.nodeName);
+      var eventIsBoundToTarget = this === target;
+
+      // Don't fire in text-accepting inputs that we didn't directly bind to
+      return eventIsBoundToTarget || !targetIsTextAreaOrSelect || !shouldFilterTextInput;
+    },
+
     // excludes: button, checkbox, file, hidden, image, password, radio, reset, search, submit, url
     textAcceptingInputTypes: [
       "text", "password", "number", "email", "url", "range", "date", "month", "week", "time", "datetime",
@@ -135,10 +147,7 @@
       keys = handleObj.data.keys.toLowerCase().split(" ");
 
     handleObj.handler = function(event) {
-      //      Don't fire in text-accepting inputs that we didn't directly bind to
-      if (this !== event.target && (/textarea|select/i.test(event.target.nodeName) ||
-        (jQuery.hotkeys.options.filterTextInputs &&
-          jQuery.inArray(event.target.type, jQuery.hotkeys.textAcceptingInputTypes) > -1))) {
+      if (!jQuery.hotkeys.filter.call(this, event)) {
         return;
       }
 

--- a/test/spec/keyBindingSpec.js
+++ b/test/spec/keyBindingSpec.js
@@ -126,6 +126,53 @@ describe("binding functions to key combinations", function() {
     }, this);
   });
 
+  it("should not trigger event handler callbacks bound to elements with contenteditable=true if not bound directly", function() {
+    var $doc = $(document);
+
+    var $el = $('<div contenteditable="true">Text!</div>');
+    this.fixture.append($el);
+
+    var spy = sinon.spy();
+    $doc.bind('keydown', 'a', spy);
+
+    var event = this.createKeyEvent('65', 'keydown');
+    $el.trigger(event);
+
+    sinon.assert.notCalled(spy);
+
+    $doc.unbind();
+    $el.remove();
+  });
+
+  it("should allow overriding filter function", function() {
+    var $doc = $(document);
+    var oldFilter = jQuery.hotkeys.filter;
+
+    var keySpy = sinon.spy();
+
+    jQuery.hotkeys.filter = function(event) {
+      expect(this).toBe($doc.get(0));
+      expect(event.target).toBe($el.get(0));
+      return true;
+    };
+
+    sinon.spy(jQuery.hotkeys, 'filter');
+
+    var $el = $('<div contenteditable="true">Text!</div>');
+    this.fixture.append($el);
+
+    $doc.bind('keydown', 'a', keySpy);
+
+    var event = this.createKeyEvent('65', 'keydown');
+    $el.trigger(event);
+
+    sinon.assert.called(keySpy);
+    sinon.assert.called(jQuery.hotkeys.filter);
+
+    jQuery.hotkeys.filter.restore();
+    jQuery.hotkeys.filter = oldFilter;
+  });
+
   it("should bind and trigger events from an input element if bound directly", function() {
 
     var i = 0;


### PR DESCRIPTION
* Don't track hotkeys triggered on a `contenteditable` element
* Support overriding filter function at Query.hotkeys.filter
* Clean up filter conditionals