### PR TITLE
Remove shiftnums as they are incompatible with non-US keyboards

### DIFF
--- a/jquery.hotkeys.js
+++ b/jquery.hotkeys.js
@@ -87,28 +87,6 @@
       222: "'"
     },
 
-    shiftNums: {
-      "`": "~",
-      "1": "!",
-      "2": "@",
-      "3": "#",
-      "4": "$",
-      "5": "%",
-      "6": "^",
-      "7": "&",
-      "8": "*",
-      "9": "(",
-      "0": ")",
-      "-": "_",
-      "=": "+",
-      ";": ": ",
-      "'": "\"",
-      ",": "<",
-      ".": ">",
-      "/": "?",
-      "\\": "|"
-    },
-
     // excludes: button, checkbox, file, hidden, image, password, radio, reset, search, submit, url
     textAcceptingInputTypes: [
       "text", "password", "number", "email", "url", "range", "date", "month", "week", "time", "datetime",
@@ -168,12 +146,6 @@
       }
       else {
         possible[modif + character] = true;
-        possible[modif + jQuery.hotkeys.shiftNums[character]] = true;
-
-        // "$" can be triggered as "Shift+4" or "Shift+$" or just "$"
-        if (modif === "shift+") {
-          possible[jQuery.hotkeys.shiftNums[character]] = true;
-        }
       }
 
       for (var i = 0, l = keys.length; i < l; i++) {


### PR DESCRIPTION
The usage of `shiftNums` to allow bindings such as `$` to indicate `Shift+4` don't work on non-US keyboard layouts.

**French keyboard**
![38565_xlargenss_ndo4211](https://cloud.githubusercontent.com/assets/201344/3985799/3c35da74-2895-11e4-95c1-d159ecd71b9e.jpg)

As you can see, the $ key is a dedicated key next to return. Binding to `$` won't actually trigger when you press the $ key, as it has keycode 220.

This issue with jquery.hotkeys was noted over two years ago https://github.com/ccampbell/mousetrap/issues/2#issuecomment-6818461, but since this repo doesn't have issues, it went unreported.

Removing this feature is not a complete fix for this problem, but I wanted to raise the issue in the form of a pull request so it's documented that this is a problem with this jQuery plugin.
