### PR TITLE
Fixed logic for filterTextInputs option

### DIFF
--- a/jquery.hotkeys.js
+++ b/jquery.hotkeys.js
@@ -139,8 +139,8 @@
 
     handleObj.handler = function(event) {
       //      Don't fire in text-accepting inputs that we didn't directly bind to
-      if (this !== event.target && (/textarea|select/i.test(event.target.nodeName) ||
-        (jQuery.hotkeys.options.filterTextInputs &&
+      if (this !== event.target && (jQuery.hotkeys.options.filterTextInputs &&
+        (/textarea|select/i.test(event.target.nodeName) ||
           jQuery.inArray(event.target.type, jQuery.hotkeys.textAcceptingInputTypes) > -1))) {
         return;
       }


### PR DESCRIPTION
The logic did not involve textarea and select fields. Now the filterTextInputs option controls these elements too.