### PR TITLE
Fixed a bug in event firing

### DIFF
--- a/jquery.hotkeys.js
+++ b/jquery.hotkeys.js
@@ -141,7 +141,9 @@
       //      Don't fire in text-accepting inputs that we didn't directly bind to
       if (this !== event.target && (/textarea|select/i.test(event.target.nodeName) ||
           (jQuery.hotkeys.options.filterTextInputs &&
-            jQuery.inArray(event.target.type, jQuery.hotkeys.textAcceptingInputTypes) > -1))) {
+            jQuery.inArray(event.target.type, jQuery.hotkeys.textAcceptingInputTypes) > -1) || 
+            jQuery(event.target).attr('contenteditable')
+            )) {
         return;
       }
 


### PR DESCRIPTION
When the user writes on a contenteditable div, the event was firing. An exception for contenteditable div's has been added.