### PR TITLE
Update jquery.hotkeys.js

### DIFF
--- a/jquery.hotkeys.js
+++ b/jquery.hotkeys.js
@@ -139,7 +139,7 @@
 
     handleObj.handler = function(event) {
       //      Don't fire in text-accepting inputs that we didn't directly bind to
-      if (this !== event.target && (/textarea|select/i.test(event.target.nodeName) ||
+      if (this !== event.target && (/textarea|input|select/i.test(event.target.nodeName) ||
           (jQuery.hotkeys.options.filterTextInputs &&
             jQuery.inArray(event.target.type, jQuery.hotkeys.textAcceptingInputTypes) > -1))) {
         return;


### PR DESCRIPTION
should also escape text-accepting inputs like search fields unless explicitly bound
